### PR TITLE
Add Tauri GUI implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,25 @@
 
 ![Lotus_boot](https://github.com/user-attachments/assets/029b4b30-81d7-48c0-8a14-ca9b2a5d36e0)
 
-This a program that takes its inspiration from Hirens BootCD. It is a fully customizable software multitool written in Python. I wrote it for SysAdmins to easly navigate systems remotely without memorizing a bunch of code or steps. Store your most used scripts in the script menu and easy have them at your disposal at alll times. I hope you enjoy. Many more to come.
+This is a customizable multitool. The GUI is now provided as a [Tauri](https://tauri.app/) application.
+
+## Building
+
+1. **Install Rust** using [rustup](https://rustup.rs):
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+2. **Install the Tauri CLI**:
+   ```bash
+   cargo install tauri-cli
+   ```
+3. **Run the application**:
+   ```bash
+   cargo tauri dev
+   ```
+   The compiled application will open with a simple "Browse Folder" button.
+
+Building a release bundle is done with:
+```bash
+cargo tauri build
+```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lotus-menu"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1.5", features = ["api-all"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+walkdir = "2"
+csv = "1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,31 @@
+use std::fs::File;
+use std::path::Path;
+use walkdir::WalkDir;
+
+use tauri::{command, api::shell, Window};
+
+#[command]
+fn scan_directory(path: String) -> Result<(), String> {
+    let file = File::create("dir_list.csv").map_err(|e| e.to_string())?;
+    let mut wtr = csv::Writer::from_writer(file);
+    for entry in WalkDir::new(&path) {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let p = entry.path().display().to_string();
+        wtr.write_record(&[p]).map_err(|e| e.to_string())?;
+    }
+    wtr.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[command]
+fn open_folder(path: String, window: Window) -> Result<(), String> {
+    shell::open(&window.shell_scope(), Path::new(&path), None)
+        .map_err(|e| e.to_string())
+}
+
+fn main() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![scan_directory, open_folder])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,19 @@
+{
+  "package": {
+    "productName": "Lotus Menu",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Lotus Menu",
+        "width": 450,
+        "height": 240
+      }
+    ],
+    "bundle": {
+      "identifier": "com.example.lotus"
+    }
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Lotus Menu</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding-top: 50px; }
+        button { padding: 10px 20px; font-size: 16px; }
+    </style>
+</head>
+<body>
+    <button id="browse">Browse Folder</button>
+    <script src="https://unpkg.com/@tauri-apps/api@1.5.0/dist/index.umd.js"></script>
+    <script>
+        const { invoke } = window.__TAURI__.tauri;
+        document.getElementById('browse').addEventListener('click', () => {
+            invoke('open_folder', { path: 'Directory' });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up a minimal Tauri project
- implement `scan_directory` and `open_folder` commands
- add a basic HTML frontend with a Browse Folder button
- document build steps

## Testing
- `cargo check` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6853260e4ac08323bad52f6e22e37d28